### PR TITLE
COMP: Fix build error removing unneeded install of multiprocessing

### DIFF
--- a/SuperBuild/External_python-whitematteranalysis.cmake
+++ b/SuperBuild/External_python-whitematteranalysis.cmake
@@ -83,13 +83,6 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       --prefix ${python_packages_DIR_NATIVE_DIR}
     )
 
-  set(_install_multiprocessing COMMAND ${CMAKE_COMMAND}
-    -E env
-      PYTHONNOUSERSITE=1
-    ${PYTHON_EXECUTABLE} -m pip install multiprocessing
-      --prefix ${python_packages_DIR_NATIVE_DIR}
-    )
-
   set(_install_xlrd COMMAND ${CMAKE_COMMAND}
     -E env
       PYTHONNOUSERSITE=1
@@ -120,7 +113,6 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     ${_install_joblib}
     ${_install_statsmodels}
     ${_install_scipy}
-    ${_install_multiprocessing}
     ${_install_xlrd}
     ${_install_whitematteranalysis}
     DEPENDS


### PR DESCRIPTION
Starting with Python 2.6, multiprocessing package is available in
python and there is no need to explicitly install the package from
pypi.

This commit fixes the following error:

  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-install-vg5p84hs/multiprocessing/setup.py", line 94
      print 'Macros:'
                    ^
  SyntaxError: Missing parentheses in call to 'print'. Did you mean print('Macros:')?