### PR TITLE
COMP: fixes prior to Slicer5 release

### DIFF
--- a/SuperBuild/External_python-whitematteranalysis.cmake
+++ b/SuperBuild/External_python-whitematteranalysis.cmake
@@ -24,7 +24,7 @@ endif()
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   if(NOT DEFINED git_protocol)
-    set(git_protocol "git")
+    set(git_protocol "https")
   endif()
 
   ExternalProject_SetIfNotDefined(
@@ -55,6 +55,12 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   set(_no_binary "")
 
+  set(_install_setuptools COMMAND ${CMAKE_COMMAND}
+    -E env
+      PYTHONNOUSERSITE=1
+    ${PYTHON_EXECUTABLE} -m pip install setuptools
+    )
+
   set(_install_cython COMMAND ${CMAKE_COMMAND}
     -E env
       PYTHONNOUSERSITE=1
@@ -80,13 +86,6 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     -E env
       PYTHONNOUSERSITE=1
     ${PYTHON_EXECUTABLE} -m pip install scipy
-      --prefix ${python_packages_DIR_NATIVE_DIR}
-    )
-
-  set(_install_multiprocessing COMMAND ${CMAKE_COMMAND}
-    -E env
-      PYTHONNOUSERSITE=1
-    ${PYTHON_EXECUTABLE} -m pip install multiprocessing
       --prefix ${python_packages_DIR_NATIVE_DIR}
     )
 
@@ -116,11 +115,11 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ${CMAKE_COMMAND} -E  echo_append ""
+    ${_install_setuptools}
     ${_install_cython}
     ${_install_joblib}
     ${_install_statsmodels}
     ${_install_scipy}
-    ${_install_multiprocessing}
     ${_install_xlrd}
     ${_install_whitematteranalysis}
     DEPENDS


### PR DESCRIPTION
* use https:// instead of deprecated git://
* install setuptools in python-install tree
* don't use old python2 multiprocessing since Slicer is
now build on python3 where the package is native