### PR TITLE
COMP: fix git/https protocol logic

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -10,9 +10,9 @@ slicer_check_cmake_https()
 #-----------------------------------------------------------------------------
 option(${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
 
-set(git_protocol "git")
+set(git_protocol "https")
 if(NOT ${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL)
-  set(git_protocol "http")
+  set(git_protocol "git")
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Use https by default unless git is specified.